### PR TITLE
Raise an exception for all non HTTP Success response codes

### DIFF
--- a/fluent-plugin-sumologic_output.gemspec
+++ b/fluent-plugin-sumologic_output.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-sumologic_output"
-  gem.version       = "0.0.3"
+  gem.version       = "0.0.4"
   gem.authors       = ["Steven Adams"]
   gem.email         = ["stevezau@gmail.com"]
   gem.description   = %q{Output plugin to SumoLogic HTTP Endpoint}

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -9,7 +9,10 @@ class SumologicConnection
   end
 
   def publish(raw_data, source_host=nil, source_category=nil, source_name=nil)
-    http.request(request_for(raw_data, source_host, source_category, source_name))
+    response = http.request(request_for(raw_data, source_host, source_category, source_name))
+    unless response.is_a?(Net::HTTPSuccess)
+      raise "Failed to send data to HTTP Source. #{response.code} - #{response.message}"
+    end
   end
 
   private


### PR DESCRIPTION
Raise an exception for all non HTTP Success response codes. Fluentd will detect this failed flush and schedule a retry later on. This is similar to memorycraft's implementation of the plugin.

Basically this fix is to address the Data Ingestion Throttling scenario, e.g.

/var/log/td-agent/td-agent.log
```
2017-05-09 17:27:07 +1000 [warn]: temporarily failed to flush the buffer. next_retry=2017-05-09 17:27:08 +1000 error_class="RuntimeError" error="Failed to send data to HTTP Source. 429 - You have temporarily exceeded your Sumo Logic quota. Please try again at a later time." plugin_id="object:3f9ef4920e64"
...
  2017-05-09 17:39:07 +1000 [warn]: suppressed same stacktrace
2017-05-09 17:39:11 +1000 [warn]: retry succeeded. plugin_id="object:3f9ef4920e64"
```

As you can see, once the ingestion / minute threshold had been breached, throttling rejected ingestion at 2017-05-09 17:27:07, and after retrying at every 10s, it eventually succeeded some time later when the ingestion rate had dropped back to normal.