### PR TITLE
Extract the source_name from FluentD's buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Configuration options for fluent.conf are:
 * `endpoint` - SumoLogic HTTP Collector URL
 * `verify_ssl` - Verify ssl certificate. (default is `true`)
 * `source_category` - Set _sourceCategory metadata field within SumoLogic (default is `nil`)
-* `source_name` - Set _sourceName metadata field within SumoLogic (default is `nil`)
+* `source_name` - Set _sourceName metadata field within SumoLogic - overrides source_name_key (default is `nil`)
+* `source_name_key` - Set as source::path_key's value so that the source_name can be extracted from Fluentd's buffer (default `source_name`)
 * `source_host` - Set _sourceHost metadata field within SumoLogic (default is `nil`)
 * `log_format` - Format to post logs into Sumo. (default `json`)
   * text - Logs will appear in SumoLogic in text format (taken from the field specified in `log_key`)

--- a/fluent-plugin-sumologic_output.gemspec
+++ b/fluent-plugin-sumologic_output.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-sumologic_output"
-  gem.version       = "0.0.4"
+  gem.version       = "0.0.5"
   gem.authors       = ["Steven Adams"]
   gem.email         = ["stevezau@gmail.com"]
   gem.description   = %q{Output plugin to SumoLogic HTTP Endpoint}

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -44,6 +44,7 @@ class Sumologic < Fluent::BufferedOutput
   config_param :log_key, :string, :default => 'message'
   config_param :source_category, :string, :default => nil
   config_param :source_name, :string, :default => nil
+  config_param :source_name_key, :string, :default => 'source_name'
   config_param :source_host, :string, :default => nil
   config_param :verify_ssl, :bool, :default => true
 
@@ -118,7 +119,7 @@ class Sumologic < Fluent::BufferedOutput
       # plugin dies randomly
       # https://github.com/uken/fluent-plugin-elasticsearch/commit/8597b5d1faf34dd1f1523bfec45852d380b26601#diff-ae62a005780cc730c558e3e4f47cc544R94
       next unless record.is_a? Hash
-      sumo_metadata = record.fetch('_sumo_metadata', {})
+      sumo_metadata = record.fetch('_sumo_metadata', {'source' => record[@source_name_key]})
       key = sumo_key(sumo_metadata)
       log_format = sumo_metadata['log_format'] || @log_format
 


### PR DESCRIPTION
When the `path` key in `<source>` is a wildcard, i.e. /var/log/*, the SumoLogic plugin should attempt to retrieve the source name from FluentD's buffer record.

One could create N amount of `<match>` records with the appropriate source_name values to cater for each log file in /var/log/*, but that would be massive amounts of config duplication.

In the following example, you need to specify a path_key in the `<source>` section, i.e. source_name, and then in the `<match>` section, specify the same value for the `source_name_key` param. Whenever new messages arrive in FluentD's buffer, the plugin will extract the value of `source_name` from the buffer.

```
<source>
  format none
  message_key event
  path /var/log/*
  path_key source_name
  ...
  tag fluent.var_log_star
  @type tail
</source>

<match>
  <store>
    ...
    endpoint https://collectors.au.sumologic.com/receiver/v1/http/ABCD
    log_format text
    log_key event
    ...
    source_category my/category/message
    source_host my-test-host
    source_name_key source_name
    @type sumologic
  </store>
  @type copy
</match>
```