### PR TITLE
Expand parameters in the output configuration

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -100,9 +100,15 @@ class Sumologic < Fluent::BufferedOutput
   end
 
   def sumo_key(sumo_metadata, record, tag)
-    source_name = expand_param(sumo_metadata['source'], tag, nil, record) || @source_name
-    source_category = expand_param(sumo_metadata['category'], tag, nil, record) || @source_category
-    source_host = expand_param(sumo_metadata['host'], tag, nil, record) || @source_host
+    source_name = sumo_metadata['source'] || @source_name
+    source_name = expand_param(source_name, tag, nil, record)
+
+    source_category = sumo_metadata['category'] || @source_category
+    source_category = expand_param(source_category, tag, nil, record)
+
+    source_host = sumo_metadata['host'] || @source_host
+    source_host = expand_param(source_host, tag, nil, record)
+    
     "#{source_name}:#{source_category}:#{source_host}"
   end
 

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -98,9 +98,7 @@ class Sumologic < Fluent::BufferedOutput
     [tag, time, record].to_msgpack
   end
 
-  def sumo_key(record, tag)
-    sumo_metadata = record.fetch('_sumo_metadata', {'source' => record[@source_name_key]})
-
+  def sumo_key(sumo_metadata, record, tag)
     source_name = expand_param(sumo_metadata['source'], tag, nil, record) || @source_name
     source_category = expand_param(sumo_metadata['category'], tag, nil, record) || @source_category
     source_host = expand_param(sumo_metadata['host'], tag, nil, record) || @source_host
@@ -150,7 +148,8 @@ class Sumologic < Fluent::BufferedOutput
       # plugin dies randomly
       # https://github.com/uken/fluent-plugin-elasticsearch/commit/8597b5d1faf34dd1f1523bfec45852d380b26601#diff-ae62a005780cc730c558e3e4f47cc544R94
       next unless record.is_a? Hash
-      key = sumo_key(record, tag)
+      sumo_metadata = record.fetch('_sumo_metadata', {'source' => record[@source_name_key]})
+      key = sumo_key(sumo_metadata, record, tag)
       log_format = sumo_metadata['log_format'] || @log_format
 
       # Strip any unwanted newlines

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -47,6 +47,7 @@ class Sumologic < Fluent::BufferedOutput
   config_param :source_name_key, :string, :default => 'source_name'
   config_param :source_host, :string, :default => nil
   config_param :verify_ssl, :bool, :default => true
+  config_param :delimiter, :string, :default => "."
 
   # This method is called before starting.
   def configure(conf)


### PR DESCRIPTION
Allow to dynamically expand parameters in the `sourceName`, `sourceCategory` and `sourceHost`  in the output configuration.

Example:
```
    source_category ${record['ecs']['docker_name']}
    source_name     ${tag_parts[0]} 
```

Closes Issue #9 