### PR TITLE
add open_timeout option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Configuration options for fluent.conf are:
   * json - Logs will appear in SumoLogic in json format.
   * json_merge - Same as json but merge content of `log_key` into the top level and strip `log_key`
 * `log_key` - Used to specify the key when merging json or sending logs in text format (default `message`)
+* `open_timeout` - Set timeout seconds to wait until connection is opened.
 
 Reading from the JSON formatted log files with `in_tail` and wildcard filenames:
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,11 @@
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |test|
+  test.libs << 'test'
+  test.pattern = 'test/**/test_*.rb'
+  test.verbose = true
+  test.warning = false
+end
+
+task :default => :test

--- a/fluent-plugin-sumologic_output.gemspec
+++ b/fluent-plugin-sumologic_output.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "bundler", "~> 1.3"
   gem.add_development_dependency "rake"
   gem.add_runtime_dependency "fluentd"
+  gem.add_development_dependency 'test-unit', '~> 3.1.0'
 end

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -3,9 +3,10 @@ require 'net/https'
 require 'yajl'
 
 class SumologicConnection
-  def initialize(endpoint, verify_ssl)
+  def initialize(endpoint, verify_ssl, open_timeout)
     @endpoint_uri = URI.parse(endpoint.strip)
     @verify_ssl = verify_ssl
+    @open_timeout = open_timeout
   end
 
   def publish(raw_data, source_host=nil, source_category=nil, source_name=nil)
@@ -30,6 +31,7 @@ class SumologicConnection
     client = Net::HTTP.new(@endpoint_uri.host, @endpoint_uri.port)
     client.use_ssl = true
     client.verify_mode = @verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+    client.open_timeout = @open_timeout
     client
   end
 end
@@ -48,6 +50,7 @@ class Sumologic < Fluent::BufferedOutput
   config_param :source_host, :string, :default => nil
   config_param :verify_ssl, :bool, :default => true
   config_param :delimiter, :string, :default => "."
+  config_param :open_timeout, :integer, :default => 60
 
   # This method is called before starting.
   def configure(conf)
@@ -59,7 +62,7 @@ class Sumologic < Fluent::BufferedOutput
       raise Fluent::ConfigError, "Invalid log_format #{conf['log_format']} must be text, json or json_merge"
     end
 
-    @sumo_conn = SumologicConnection.new(conf['endpoint'], conf['verify_ssl'])
+    @sumo_conn = SumologicConnection.new(conf['endpoint'], conf['verify_ssl'], conf['open_timeout'].to_i)
     super
   end
 
@@ -108,7 +111,7 @@ class Sumologic < Fluent::BufferedOutput
 
     source_host = sumo_metadata['host'] || @source_host
     source_host = expand_param(source_host, tag, nil, record)
-    
+
     "#{source_name}:#{source_category}:#{source_host}"
   end
 

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -59,7 +59,7 @@ class Sumologic < Fluent::BufferedOutput
       raise Fluent::ConfigError, "Invalid log_format #{conf['log_format']} must be text, json or json_merge"
     end
 
-    @sumo_conn = SumologicConnection.new(conf['endpoint'], @verify_ssl)
+    @sumo_conn = SumologicConnection.new(conf['endpoint'], conf['verify_ssl'])
     super
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,2 @@
+require 'test/unit'
+require 'fluent/test'

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -1,0 +1,41 @@
+require 'helper'
+require 'fluent/test/driver/output'
+
+class SumologicOutput < Test::Unit::TestCase
+  def setup
+    Fluent::Test.setup
+    require 'fluent/plugin/out_sumologic'
+    @driver = nil
+    log = Fluent::Engine.log
+    log.out.logs.slice!(0, log.out.logs.length)
+  end
+
+  def driver(conf='')
+    @driver ||= Fluent::Test::Driver::Output.new(Sumologic).configure(conf)
+  end
+
+  def test_configure
+    config = %{
+      endpoint        https://SUMOLOGIC_URL
+      log_format      text
+      log_key         LOG_KEY
+      source_category SOURCE_CATEGORY
+      source_name     SOURCE_NAME
+      source_name_key SOURCE_NAME_KEY
+      source_host     SOURCE_HOST
+      verify_ssl      false
+      open_timeout    10
+    }
+    instance = driver(config).instance
+
+    assert_equal instance.endpoint, 'https://SUMOLOGIC_URL'
+    assert_equal instance.log_format, 'text'
+    assert_equal instance.log_key, 'LOG_KEY'
+    assert_equal instance.source_category, 'SOURCE_CATEGORY'
+    assert_equal instance.source_name, 'SOURCE_NAME'
+    assert_equal instance.source_name_key, 'SOURCE_NAME_KEY'
+    assert_equal instance.source_host, 'SOURCE_HOST'
+    assert_equal instance.verify_ssl, false
+    assert_equal instance.open_timeout, 10
+  end
+end


### PR DESCRIPTION
In past http lib, the `open_timeout` default value is `nil`.
https://github.com/ruby/ruby/blob/v2_1_0/lib/net/http.rb#L644

And, some fluentd plugin has the option.
https://github.com/fluent/fluent-plugin-webhdfs

I think it is worthful to add.