### PR TITLE
Add client header for fluentd output

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -25,7 +25,8 @@ class SumologicConnection
     {
         'X-Sumo-Name'     => source_name,
         'X-Sumo-Category' => source_category,
-        'X-Sumo-Host'     => source_host
+        'X-Sumo-Host'     => source_host,
+        'X-Sumo-Client'   => 'fluentd-output'
     }
   end
 


### PR DESCRIPTION
Adds the `X-Sumo-Client` header as part of our initiative to track HTTP collection usage.

Verified the header is sent with log message payload.