### PR TITLE
specify version of fluentd

### DIFF
--- a/fluent-plugin-sumologic_output.gemspec
+++ b/fluent-plugin-sumologic_output.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler", "~> 1.3"
   gem.add_development_dependency "rake"
-  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency "fluentd", ">= 0.14.0"
   gem.add_development_dependency 'test-unit', '~> 3.1.0'
 
   gem.add_runtime_dependency 'httpclient', '~> 2.8.0'


### PR DESCRIPTION
Current version of this plugin can't use in v0.12. ( #12 )