### PR TITLE
ISSUE #25: Adding proxy capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Configuration options for fluent.conf are:
 * `log_key` - Used to specify the key when merging json or sending logs in text format (default `message`)
 * `open_timeout` - Set timeout seconds to wait until connection is opened.
 * `add_timestamp` - Add `timestamp` field to logs before sending to sumologic (default `true`)
-* `proxy_uri` - Add the `uri` of the `proxy` environment if present.@michnmi looks good. Can you update the readme and also allow the ENV setting and then we can merge and cut a new release.
+* `proxy_uri` - Add the `uri` of the `proxy` environment if present.
 
 Reading from the JSON formatted log files with `in_tail` and wildcard filenames:
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Configuration options for fluent.conf are:
 * `log_key` - Used to specify the key when merging json or sending logs in text format (default `message`)
 * `open_timeout` - Set timeout seconds to wait until connection is opened.
 * `add_timestamp` - Add `timestamp` field to logs before sending to sumologic (default `true`)
+* `proxy_uri` - Add the `uri` of the `proxy` environment if present.@michnmi looks good. Can you update the readme and also allow the ENV setting and then we can merge and cut a new release.
 
 Reading from the JSON formatted log files with `in_tail` and wildcard filenames:
 ```


### PR DESCRIPTION
This allows #25 to happen. 
It accepts `proxy_uri` as a parameter in `match` and then we can use it in the `HTTPCLIENT` connetion. 
It does not allow for the `ENV` setting to be used *yet* as this is a quick fix that I need. 
MM