### PR TITLE
Don't chomp if the message is not chomp-able

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -195,7 +195,7 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
       log_format    = sumo_metadata['log_format'] || @log_format
 
       # Strip any unwanted newlines
-      record[@log_key].chomp! if record[@log_key]
+      record[@log_key].chomp! if record[@log_key] && record[@log_key].respond_to?(:chomp!)
 
       case log_format
         when 'text'


### PR DESCRIPTION
### Summary

fixes #26 

This change ensures that log messages that include a key `message` that is not a string (or, more precisely, do not respond to `chomp!`) will not raise errors when trying to strip newlines.

