### PR TITLE
Add support for collected fields 

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -245,6 +245,7 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
       sumo_metadata = record.fetch('_sumo_metadata', {:source => record[@source_name_key] })
       key           = sumo_key(sumo_metadata, record, tag)
       log_format    = sumo_metadata['log_format'] || @log_format
+      log_fields    = sumo_metadata['fields'] || ""
 
       # Strip any unwanted newlines
       record[@log_key].chomp! if record[@log_key] && record[@log_key].respond_to?(:chomp!)
@@ -268,7 +269,7 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
           end
           merged_hash = merge_json(record)
           log = dump_log(merged_hash.slice(:timestamp, @log_key))
-          log_fields = merged_hash.select {|k,v| (k != :timestamp && k != @log_key)}.map{|k,v| "#{k}=#{v}"}.join(',')
+          log_fields << merged_hash.select {|k,v| (k != :timestamp && k != @log_key)}.map{|k,v| "#{k}=#{v}"}.join(',')
         else
           if @add_timestamp
             record = { :timestamp => sumo_timestamp(time) }.merge(record)

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -36,7 +36,7 @@ class SumologicConnection
         raise RuntimeError, "Invalid #{metric_data_format}, must be graphite or carbon2"
       end
     end
-    if !collected_fields.nil?
+    unless collected_fields.nil?
       headers['X-Sumo-Fields'] = collected_fields
     end
     return headers

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -213,6 +213,14 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
     ]
   end
 
+  def dump_collected_fileds(log_fields)
+    if log_fields.nil?
+      log_fields
+    else
+      log_fields.map{|k,v| "#{k}=#{v}"}.join(',')
+    end
+  end
+
   # copy from https://github.com/uken/fluent-plugin-elasticsearch/commit/1722c58758b4da82f596ecb0a5075d3cb6c99b2e#diff-33bfa932bf1443760673c69df745272eR221
   def expand_param(param, tag, time, record)
     # check for '${ ... }'
@@ -256,7 +264,10 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
       sumo_metadata = record.fetch('_sumo_metadata', {:source => record[@source_name_key] })
       key           = sumo_key(sumo_metadata, record, tag)
       log_format    = sumo_metadata['log_format'] || @log_format
-      log_fields    = sumo_fields(sumo_metadata)
+
+      if log_format.eql? 'fields'
+        log_fields    = sumo_fields(sumo_metadata)
+      end
 
       # Strip any unwanted newlines
       record[@log_key].chomp! if record[@log_key] && record[@log_key].respond_to?(:chomp!)
@@ -315,7 +326,7 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
           source_name         =source_name,
           data_type           =@data_type,
           metric_data_format  =@metric_data_format,
-          collected_fields    =log_fields.map{|k,v| "#{k}=#{v}"}.join(',')
+          collected_fields    =dump_collected_fileds(log_fields)
       )
     end
 

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -43,7 +43,7 @@ class SumologicConnection
   end
 
   def ssl_options(verify_ssl)
-    verify_ssl ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+    verify_ssl==true ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
   end
 
   def create_http_client(verify_ssl, connect_timeout, proxy_uri, disable_cookies)

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -292,7 +292,7 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
           merged_hash = merge_json(record)
           log = dump_log(merged_hash.slice(:timestamp, @log_key))
           fields_from_payload = merged_hash.select {|k,v| (k != :timestamp && k != @log_key && k != '_sumo_metadata')}
-          log_fields = fields_from_payload.merge(log_fields)
+          log_fields = log_fields.merge(fields_from_payload)
         else
           if @add_timestamp
             record = { :timestamp => sumo_timestamp(time) }.merge(record)

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -290,9 +290,7 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
             record = { :timestamp => sumo_timestamp(time) }.merge(record)
           end
           merged_hash = merge_json(record)
-          puts 11
           log = dump_log(merged_hash.select {|k,v| [:timestamp, @log_key].include?(k)})
-          puts 6
           fields_from_payload = merged_hash.select {|k,v| (k != :timestamp && k != @log_key && k != '_sumo_metadata')}
           log_fields = log_fields.merge(fields_from_payload)
         else

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -290,7 +290,9 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
             record = { :timestamp => sumo_timestamp(time) }.merge(record)
           end
           merged_hash = merge_json(record)
-          log = dump_log(merged_hash.slice(:timestamp, @log_key))
+          puts 11
+          log = dump_log(merged_hash.select {|k,v| [:timestamp, @log_key].include?(k)})
+          puts 6
           fields_from_payload = merged_hash.select {|k,v| (k != :timestamp && k != @log_key && k != '_sumo_metadata')}
           log_fields = log_fields.merge(fields_from_payload)
         else

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -136,6 +136,28 @@ class SumologicOutput < Test::Unit::TestCase
                      times:1
   end
 
+  def test_emit_fields_no_timestamp
+    config = %{
+      endpoint        https://collectors.sumologic.com/v1/receivers/http/1234
+      log_format      fields
+      source_category test
+      source_host     test
+      source_name     test
+      add_timestamp   false
+
+    }
+    driver = create_driver(config)
+    time = event_time
+    stub_request(:post, 'https://collectors.sumologic.com/v1/receivers/http/1234')
+    driver.run do
+      driver.feed("output.test", time, {'foo' => 'bar', 'sumo ' => 'logic', 'message' => 'test'})
+    end
+    assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
+                     headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'test', 'X-Sumo-Name'=>'test', 'X-Sumo-Fields' => 'foo=bar,sumo =logic'},
+                     body: /\A{"message":"test"}\z/,
+                     times:1
+  end
+
   def test_emit_json_double_encoded
     config = %{
       endpoint        https://endpoint3.collection.us2.sumologic.com/receiver/v1/http/1234

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -297,11 +297,11 @@ class SumologicOutput < Test::Unit::TestCase
     stub_request(:post, 'https://collectors.sumologic.com/v1/receivers/http/1234')
     ENV['HOST'] = "foo"
     driver.run do
-      driver.feed("output.test", time, {'foo' => 'bar', 'message' => 'test', '_sumo_metadata' => {
+      driver.feed("output.test", time, {'foo' => 'shark', 'message' => 'test', '_sumo_metadata' => {
           "host": "#{ENV['HOST']}",
           "source": "${tag}",
           "category": "test",
-          "fields": "foo=shark, sumo = logic"
+          "fields": "foo=bar, sumo = logic"
       }})
     end
     assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -136,6 +136,27 @@ class SumologicOutput < Test::Unit::TestCase
                      times:1
   end
 
+  def test_emit_empty_fields
+    config = %{
+      endpoint        https://collectors.sumologic.com/v1/receivers/http/1234
+      log_format      fields
+      source_category test
+      source_host     test
+      source_name     test
+
+    }
+    driver = create_driver(config)
+    time = event_time
+    stub_request(:post, 'https://collectors.sumologic.com/v1/receivers/http/1234')
+    driver.run do
+      driver.feed("output.test", time, {'message' => 'test'})
+    end
+    assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
+                     headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'test', 'X-Sumo-Name'=>'test'},
+                     body: /\A{"timestamp":\d+.,"message":"test"}\z/,
+                     times:1
+  end
+
   def test_emit_fields_no_timestamp
     config = %{
       endpoint        https://collectors.sumologic.com/v1/receivers/http/1234

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -301,11 +301,11 @@ class SumologicOutput < Test::Unit::TestCase
           "host": "#{ENV['HOST']}",
           "source": "${tag}",
           "category": "test",
-          "fields": "foo=bar, sumo = logic"
+          "fields": "foo=shark, sumo = logic"
       }})
     end
     assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
-                     headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'foo', 'X-Sumo-Name'=>'output.test', 'X-Sumo-Fields' => 'foo=bar, sumo = logic'},
+                     headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'foo', 'X-Sumo-Name'=>'output.test', 'X-Sumo-Fields' => 'foo=shark, sumo = logic'},
                      body: /\A{"timestamp":\d+.,"message":"test"}\z/,
                      times:1
   end

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -282,7 +282,7 @@ class SumologicOutput < Test::Unit::TestCase
       }})
     end
     assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
-                     headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'foo', 'X-Sumo-Name'=>'output.test', 'X-Sumo-Fields' => 'foo=bar, sumo = logic'},
+                     headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'foo', 'X-Sumo-Name'=>'output.test'},
                      body: /\A{"timestamp":\d+.,"foo":"bar","message":"test"}\z/,
                      times:1
   end


### PR DESCRIPTION
To enable ingesting log metadata as part of http headers, this change introduces a new `log_format: fields`.  **Behavior for other log_formats remains unchanged.**
When log_format is specified as fields , we will be looking for metadata fields in two locations: 
-  *fields* in `_sumo_metadata`, we would expect comma separated key value pairs. 
    [TODO: Validation to be added]
- Any other fields from the log_message, which are neither `timestamp` nor `log_key`. 

*In case the same key is present in _sumo_metadata & the log_message, the value from the log_message will be selected as final.* 
See test: test_emit_with_sumo_metadata_with_fields_fields_format

After merging we set collected fields as header field 'X-Sumo-Fields' in a comma separated key value format. 





