### PR TITLE
Add "timestamp_key", prefer log message when merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Configuration options for fluent.conf are:
   * json_merge - Same as json but merge content of `log_key` into the top level and strip `log_key`
 * `log_key` - Used to specify the key when merging json or sending logs in text format (default `message`)
 * `open_timeout` - Set timeout seconds to wait until connection is opened.
-* `add_timestamp` - Add `timestamp` field to logs before sending to sumologic (default `true`)
+* `add_timestamp` - Add `timestamp` (or `timestamp_key`) field to logs before sending to sumologic (default `true`)
+* `timestamp_key` - Field name when `add_timestamp` is on (default `timestamp`)
 * `proxy_uri` - Add the `uri` of the `proxy` environment if present.
 * `metric_data_format` - The format of metrics you will be sending, either `graphite` or `carbon2` (Default is `graphite `)
 * `disable_cookies` - Option to disable cookies on the HTTP Client. (Default is `false `)

--- a/fluent-plugin-sumologic_output.gemspec
+++ b/fluent-plugin-sumologic_output.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0.0'
 
-  gem.add_development_dependency "bundler", "~> 1.3"
+  gem.add_development_dependency "bundler", "~> 2"
   gem.add_development_dependency "rake"
   gem.add_development_dependency 'test-unit', '~> 3.1.0'
   gem.add_development_dependency "codecov", ">= 0.1.10"

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -146,7 +146,7 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
       log = record[@log_key].strip
       if log[0].eql?('{') && log[-1].eql?('}')
         begin
-          record = JSON.parse(log).merge(record)
+          record = record.merge(JSON.parse(log))
           record.delete(@log_key)
         rescue JSON::ParserError
           # do nothing, ignore

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -80,6 +80,7 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
   config_param :delimiter, :string, :default => "."
   config_param :open_timeout, :integer, :default => 60
   config_param :add_timestamp, :bool, :default => true
+  config_param :timestamp_key, :string, :default => 'timestamp'
   config_param :proxy_uri, :string, :default => nil
   config_param :disable_cookies, :bool, :default => false
 
@@ -255,12 +256,12 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
           end
         when 'json_merge'
           if @add_timestamp
-            record = { :timestamp => sumo_timestamp(time) }.merge(record)
+            record = { @timestamp_key => sumo_timestamp(time) }.merge(record)
           end
           log = dump_log(merge_json(record))
         else
           if @add_timestamp
-            record = { :timestamp => sumo_timestamp(time) }.merge(record)
+            record = { @timestamp_key => sumo_timestamp(time) }.merge(record)
           end
           log = dump_log(record)
         end

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -179,6 +179,27 @@ class SumologicOutput < Test::Unit::TestCase
                      times:1
   end
 
+  def test_emit_json_merge_timestamp
+    config = %{
+      endpoint        https://collectors.sumologic.com/v1/receivers/http/1234
+      log_format      json_merge
+      source_category test
+      source_host     test
+      source_name     test
+
+    }
+    driver = create_driver(config)
+    time = event_time
+    stub_request(:post, 'https://collectors.sumologic.com/v1/receivers/http/1234')
+    driver.run do
+      driver.feed("output.test", time, {'message' => '{"timestamp":123}'})
+    end
+    assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
+                     headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'test', 'X-Sumo-Name'=>'test'},
+                     body: /\A{"timestamp":123}\z/,
+                     times:1
+  end
+
   def test_emit_with_sumo_metadata
     config = %{
       endpoint        https://collectors.sumologic.com/v1/receivers/http/1234

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -175,7 +175,7 @@ class SumologicOutput < Test::Unit::TestCase
     end
     assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
                      headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'test', 'X-Sumo-Name'=>'test'},
-                     body: /\A{"foo2":"bar2","timestamp":\d+,"foo":"bar"}\z/,
+                     body: /\A{"timestamp":\d+,"foo":"bar","foo2":"bar2"}\z/,
                      times:1
   end
 


### PR DESCRIPTION
* Adds `timestamp_key` property, which allows the user to customize the default key of `timestamp` (+ tests)
* Changes merge order of `json_merge` so that the log message wins over the record data in cases of conflict (+ tests)
* Updates bundler to 2 (unrelated, required to run tests)

### Notes

* Switching the symbol key (`{ :timestamp => 123 }`) to a string `{ 'timestamp' => 123 }` is important. `JSON.dump({ :foo => 'bar', 'foo' => 'qux' })` will return `{"foo:"bar","foo":"qux"}` so we need key types to match.
* The change in merge order is the most invasive but it seems sensible to prioritize user data over record data in the event of conflict. I doubt anyone has run into this yet and I had to write a failing test to understand how it works.

### Motivation

[Scoop](https://github.com/takescoop/) uses a standard logging library across our apps that emits newline-delimited JSON. It includes timestamps as `{"time": 123}`. A dev noticed that log lines from Kubernetes contained both `timestamp` and `time`. Because we use `json_merge`, both properties appear at the same level. We'd like to configure fluentd to render a timestamp as `time` to any log line missing it (including non-JSON) but not overwrite an existing `time` property in JSON lines.