### PR TITLE
Byi fix bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.rbc
 Gemfile.lock
 .idea/
+TAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 lang: ruby
-script: bundle exec rake
-rvm: 2.3
+script: ci/build.sh
 deploy:
   provider: rubygems
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 lang: ruby
+before_install: gem install bundler
 script: ci/build.sh
 deploy:
   provider: rubygems

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -3,9 +3,6 @@
 echo "Starting build process in: `pwd`"
 set -e
 
-echo "Install bundler..."
-gem install bundler
-
 if [! -z "${TRAVIS_TAG}" ]; then
     echo "Building for tag ${TRAVIS_TAG}, modify .gemspec file..."
     sed -i '' "s/0.0.0/${TRAVIS_TAG}/g" ./fluent-plugin-sumologic_output.gemspec

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "Starting build process in: `pwd`"
+set -e
+
+echo "Install bundler..."
+gem install bundler
+
+if [! -z "${TRAVIS_TAG}" ]; then
+    echo "Building for tag ${TRAVIS_TAG}, modify .gemspec file..."
+    sed -i '' "s/0.0.0/${TRAVIS_TAG}/g" ./fluent-plugin-sumologic_output.gemspec
+fi
+
+echo "Install bundler..."
+bundle install
+
+echo "Run unit tests..."
+bundle exec rake
+
+echo "DONE"

--- a/fluent-plugin-sumologic_output.gemspec
+++ b/fluent-plugin-sumologic_output.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = "fluent-plugin-sumologic_output"
-  gem.version       = "1.4.1"
+  gem.version       = "0.0.0"
   gem.authors       = ["Steven Adams", "Frank Reno"]
   gem.email         = ["stevezau@gmail.com", "frank.reno@me.com"]
   gem.description   = %q{Output plugin to SumoLogic HTTP Endpoint}
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}) { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.has_rdoc      = false
 
   gem.required_ruby_version = '>= 2.0.0'
 


### PR DESCRIPTION
Travis build randomly failure on missing bundler 2.x
add a before_install step to avoid it
also try to use a bash script to auto pop version string from `TRAVIS_TAG`