### PR TITLE
Add source_category_prefix. Local config has precedence.

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -76,6 +76,7 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
   config_param :log_format, :string, :default => 'json'
   config_param :log_key, :string, :default => 'message'
   config_param :source_category, :string, :default => nil
+  config_param :source_category_prefix, :string, :default => nil
   config_param :source_name, :string, :default => nil
   config_param :source_name_key, :string, :default => 'source_name'
   config_param :source_host, :string, :default => nil
@@ -186,13 +187,14 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
   end
 
   def sumo_key(sumo_metadata, chunk)
-    source_name = sumo_metadata['source'] || @source_name
+    source_name = @source_name || sumo_metadata['source']
     source_name = extract_placeholders(source_name, chunk) unless source_name.nil?
 
-    source_category = sumo_metadata['category'] || @source_category
+    source_category = @source_category || sumo_metadata['category']
+    source_category.prepend(@source_category_prefix) unless @source_category_prefix.nil? or source_category.nil?
     source_category = extract_placeholders(source_category, chunk) unless source_category.nil?
 
-    source_host = sumo_metadata['host'] || @source_host
+    source_host = @source_host || sumo_metadata['host']
     source_host = extract_placeholders(source_host, chunk) unless source_host.nil?
 
     "#{source_name}:#{source_category}:#{source_host}"


### PR DESCRIPTION
We recently faced a migration process between 2 different sumologic accounts. In the process there is a time span where we need to forward logs to both accounts. We've found out a couple of things when using the Sumologic filter.

The filter sets sumologic metadata and even if we set the config values in the output plugin (`source_category` namely), they were being silently ignored as there was already a value set by the filter earlier on in the evaluation chain.

In our case, different accounts used different `sourceCategory` prefixes. While the filter plugin has a `source_category` and `source_category_prefix` config params, the output plugin has only `source_category`. By adding the prefix config param, we are able to prepend a string to the category set by the filter plugin.

Because of these, this PR:
- Adds a `source_category_prefix` config param, `nil` by default. If set to a string, it will be prepended to the `source_category` string (provided it is not `nil`).
- Prioritise local config params `source_name`, `source_category` and `source_host` over the ones that could exist in the metadata keys.