### PR TITLE
[breaking change] remove log_format

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -172,16 +172,6 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
     "#{source_name}:#{source_category}:#{source_host}"
   end
 
-  def sumo_fields(sumo_metadata)
-    fields = sumo_metadata['fields'] || ""
-    Hash[
-      fields.split(',').map do |pair|
-        k, v = pair.split('=', 2)
-        [k, v]
-      end
-    ]
-  end
-
   def dump_collected_fields(log_fields)
     if log_fields.nil?
       log_fields
@@ -208,7 +198,7 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
 
       case @data_type
       when 'logs'
-        log_fields = sumo_fields(sumo_metadata)
+        log_fields = sumo_metadata['fields']
         log = dump_log(record)
       when 'metrics'
         log = record[@log_key]

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -81,8 +81,6 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
   config_param :verify_ssl, :bool, :default => true
   config_param :delimiter, :string, :default => "."
   config_param :open_timeout, :integer, :default => 60
-  config_param :add_timestamp, :bool, :default => true
-  config_param :timestamp_key, :string, :default => 'timestamp'
   config_param :proxy_uri, :string, :default => nil
   config_param :disable_cookies, :bool, :default => false
 

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -58,8 +58,6 @@ class SumologicOutput < Test::Unit::TestCase
     assert_equal instance.verify_ssl, true
     assert_equal instance.delimiter, '.'
     assert_equal instance.open_timeout, 60
-    assert_equal instance.add_timestamp, true
-    assert_equal instance.timestamp_key, 'timestamp'
     assert_equal instance.proxy_uri, nil
     assert_equal instance.disable_cookies, false
   end

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -116,7 +116,7 @@ class SumologicOutput < Test::Unit::TestCase
           "host": "#{ENV['HOST']}",
           "source": "${tag}",
           "category": "test",
-          "fields": "foo=bar, sumo = logic"
+          "fields": {"foo"=>"bar", " sumo " => " logic"}
       }})
     end
     assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
@@ -141,7 +141,7 @@ class SumologicOutput < Test::Unit::TestCase
           "host": "#{ENV['HOST']}",
           "source": "${tag}",
           "category": "test",
-          "fields": "foo=bar, sumo = logic"
+          "fields": {"foo"=>"bar", " sumo " => " logic"}
       }})
     end
     assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
@@ -166,7 +166,7 @@ class SumologicOutput < Test::Unit::TestCase
           "host": "#{ENV['HOST']}",
           "source": "${tag}",
           "category": "test",
-          "fields": "foo=bar, sumo = logic"
+          "fields": {"foo"=>"bar", " sumo " => " logic"}
       }})
     end
     assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
@@ -192,7 +192,7 @@ class SumologicOutput < Test::Unit::TestCase
           "host": "#{ENV['HOST']}",
           "source": "${tag}",
           "category": "test",
-          "fields": "foo=bar, sumo = logic"
+          "fields": {"foo"=>"bar", " sumo " => " logic"}
       }})
     end
     assert_requested :post, "https://collectors.sumologic.com/v1/receivers/http/1234",


### PR DESCRIPTION
As part of our new kubernetes solution, we are pursuing more declarative config all around. Some configuration that we currently support like `log_format` or `add_timestamp` could instead be done in a filter plugin like the `record_modifier` plugin.

However, in order to support both `text` type formats and `json` type formats, while also preserving `_sumo_metadata`, we need to change the expected format of the input. Now the log message to be sent to sumo is wrapped in the `"message"` key, as shown in the unit tests

This is a breaking change and will require a major release `2.0.0`