### PR TITLE
Fix sumo_key hash tuple to support colons

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -198,7 +198,8 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
     fields = sumo_metadata['fields'] || ""
     fields = extract_placeholders(fields, chunk) unless fields.nil?
 
-    "#{source_name}:#{source_category}:#{source_host}:#{fields}"
+    { :source_name => "#{source_name}", :source_category => "#{source_category}",
+      :source_host => "#{source_host}", :fields => "#{fields}" }
   end
 
   # Convert timestamp to 13 digit epoch if necessary
@@ -265,7 +266,8 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
 
     # Push logs to sumo
     messages_list.each do |key, messages|
-      source_name, source_category, source_host, fields = key.split(':')
+      source_name, source_category, source_host, fields = key[:source_name], key[:source_category],
+        key[:source_host], key[:fields]
       @sumo_conn.publish(
           messages.join("\n"),
           source_host         =source_host,

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -455,7 +455,7 @@ class SumologicOutput < Test::Unit::TestCase
       driver.feed("output.test", time, {'message' => 'test1'})
       driver.feed("output.test", time, {'message' => 'test2', '_sumo_metadata' => {"fields": "foo=bar"}})
       driver.feed("output.test", time, {'message' => 'test3', '_sumo_metadata' => {"fields": "foo=bar,sumo=logic"}})
-      driver.feed("output.test", time, {'message' => 'test4', '_sumo_metadata' => {"fields": "foo=bar,abc=123"}})
+      driver.feed("output.test", time, {'message' => 'test4', '_sumo_metadata' => {"fields": "foo=bar,master_url=https://100.64.0.1:443"}})
     end
     assert_requested  :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
                       headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'test', 'X-Sumo-Name'=>'test'},
@@ -470,7 +470,7 @@ class SumologicOutput < Test::Unit::TestCase
                       body: /\A{"timestamp":\d+.,"message":"test3"}\z/,
                       times:1
     assert_requested  :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
-                      headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'test', 'X-Sumo-Name'=>'test', 'X-Sumo-Fields' => 'foo=bar,abc=123'},
+                      headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'test', 'X-Sumo-Name'=>'test', 'X-Sumo-Fields' => 'foo=bar,master_url=https://100.64.0.1:443'},
                       body: /\A{"timestamp":\d+.,"message":"test4"}\z/,
                       times:1
   end


### PR DESCRIPTION
Addresses issue from https://github.com/SumoLogic/fluentd-output-sumologic/pull/54/files#r335225163 to add support for colons in the `sumo_key` hash tuple.

This seems to work since hash tuples in Ruby use the content as well: https://www.ruby-forum.com/t/how-to-use-tuple-as-hash-key/114797/2

We will need to make a new release and then update the gem dependency in our Dockerfile in the Kubernetes project.