### PR TITLE
Fix configuration for older fluentd versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. Tracking did not begin until version 1.10.
 
+<a name="1.7.1"></a>
+# [1.7.1] (2020-04-28)
+- Fix configuration for older fluentd versions [#63](https://github.com/SumoLogic/fluentd-output-sumologic/pull/63)
+
 <a name="1.7.0"></a>
 # [1.7.0] (2020-04-23)
 - Add option for specifing custom fields for logs: [#56](https://github.com/SumoLogic/fluentd-output-sumologic/pull/56)

--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -186,13 +186,19 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
     end
 
     conf['custom_fields'] = validate_key_value_pairs(conf['custom_fields'])
+    if conf['custom_fields'].nil?
+      conf.delete 'custom_fields'
+    end
     unless conf['custom_fields']
-      @log.info "Custom fields: #{conf['custom_fields']}"
+      @log.debug "Custom fields: #{conf['custom_fields']}"
     end
 
     conf['custom_dimensions'] = validate_key_value_pairs(conf['custom_dimensions'])
+    if conf['custom_dimensions'].nil?
+      conf.delete 'custom_dimensions'
+    end
     unless conf['custom_dimensions']
-      @log.info "Custom dimensions: #{conf['custom_dimensions']}"
+      @log.debug "Custom dimensions: #{conf['custom_dimensions']}"
     end
 
     # For some reason default is set incorrectly in unit-tests


### PR DESCRIPTION
Fluentd in older versions (like 1.2.6) expects that configuration hashmap has no key rather than nil value

Fixes: #62