### PR TITLE
Don't concatenate buffer results

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -362,16 +362,18 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
         fields = [fields,@custom_fields].compact.join(",")
       end
 
-      @sumo_conn.publish(
-          messages.join("\n"),
-          source_host         =source_host,
-          source_category     =source_category,
-          source_name         =source_name,
-          data_type           =@data_type,
-          metric_data_format  =@metric_data_format,
-          collected_fields    =fields,
-          dimensions          =@custom_dimensions
-      )
+      messages.each do |message|
+        @sumo_conn.publish(
+            message,
+            source_host         =source_host,
+            source_category     =source_category,
+            source_name         =source_name,
+            data_type           =@data_type,
+            metric_data_format  =@metric_data_format,
+            collected_fields    =fields,
+            dimensions          =@custom_dimensions
+        )
+      end
     end
 
   end

--- a/test/plugin/test_out_sumologic.rb
+++ b/test/plugin/test_out_sumologic.rb
@@ -545,27 +545,6 @@ class SumologicOutput < Test::Unit::TestCase
                      times:1
   end
 
-  def test_batching_same_headers
-    config = %{
-      endpoint        https://collectors.sumologic.com/v1/receivers/http/1234
-      log_format      json
-      source_category test
-      source_host     test
-      source_name     test
-    }
-    driver = create_driver(config)
-    time = event_time
-    stub_request(:post, 'https://collectors.sumologic.com/v1/receivers/http/1234')
-    driver.run do
-      driver.feed("output.test", time, {'message' => 'test1'})
-      driver.feed("output.test", time, {'message' => 'test2'})
-    end
-    assert_requested  :post, "https://collectors.sumologic.com/v1/receivers/http/1234",
-                      headers: {'X-Sumo-Category'=>'test', 'X-Sumo-Client'=>'fluentd-output', 'X-Sumo-Host'=>'test', 'X-Sumo-Name'=>'test'},
-                      body: /\A{"timestamp":\d+.,"message":"test1"}\n{"timestamp":\d+.,"message":"test2"}\z/,
-                      times:1
-  end
-
   def test_batching_different_headers
     config = %{
       endpoint        https://collectors.sumologic.com/v1/receivers/http/1234


### PR DESCRIPTION
Joining records back together while batching sends
causes problems for multiline parsing.

For example, with the records

```
2020-10-05T10:00:00Z First line of an error message
  second line of an error message
2020-10-05T10:00:00Z A different error message
```

if multiline parsing is set correctly, we expect this
to be split into two records, the first
of two lines and the second of one line. However, if
records are joined at the point of sumo publishing, then
we may well get all three lines as a single record.

This is mostly a problem for multiline parsing as you can
treat each line as an individual message if multiline is
not used, but you cannot do that if needing to do the
multiline separation before sending to sumo.
