### PR TITLE
Expose httpclient send_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Configuration options for fluent.conf are:
   * json_merge - Same as json but merge content of `log_key` into the top level and strip `log_key`
 * `log_key` - Used to specify the key when merging json or sending logs in text format (default `message`)
 * `open_timeout` - Set timeout seconds to wait until connection is opened.
+* `send_timeout` - Timeout for sending to SumoLogic in seconds. Don't modify unless you see `HTTPClient::SendTimeoutError` in your Fluentd logs. (default `120`)
 * `add_timestamp` - Add `timestamp` (or `timestamp_key`) field to logs before sending to sumologic (default `true`)
 * `timestamp_key` - Field name when `add_timestamp` is on (default `timestamp`)
 * `proxy_uri` - Add the `uri` of the `proxy` environment if present.


### PR DESCRIPTION
This exposes the httpclient send_timeout property to configuration by end-user. This can be useful when the user is receiving error messages like `#0 failed to flush the buffer. retry_time=0 next_retry_seconds=2021-07-20 17:26:24.606606697 +0000 chunk="REMOVED" error_class=HTTPClient::SendTimeoutError error="execution expired"` as the send_timeout can be increased until the chunk can be flushed.