### PR TITLE
feat(max_request_size): add max_request_size to limit size of requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Configuration options for fluent.conf are:
 * `retry_max_interval` - Maximum interval to wait between sending tries (default is `5m`)
 * `retry_timeout` - Time after which the data is going to be dropped (default is `72h`) (`0s` means that there is no timeout)
 * `retry_max_times` - Maximum number of retries (default is `0`) (`0` means that there is no max retry times, retries will happen forever)
+* `max_request_size` - Maximum request size (before applying compression). Default is `0k` which means no limit
 
 __NOTE:__ <sup>*</sup> [Placeholders](https://docs.fluentd.org/v1.0/articles/buffer-section#placeholders) are supported
 


### PR DESCRIPTION
Adds records_per_request on the top of retry changes. This is going to limit maximum number of records in request. This is because for bigger chunks, there is possibility to get send_timeout because of cancelling the request by receiver