### PR TITLE
feat: log warning if log_key does not exist in log

### DIFF
--- a/lib/fluent/plugin/out_sumologic.rb
+++ b/lib/fluent/plugin/out_sumologic.rb
@@ -367,6 +367,9 @@ class Fluent::Plugin::Sumologic < Fluent::Plugin::Output
       when 'logs'
         case log_format
         when 'text'
+          if !record.has_key?(@log_key)
+            log.warn "log key `#{@log_key}` has not been found in the log"
+          end
           log = log_to_str(record[@log_key])
         when 'json_merge'
           if @add_timestamp


### PR DESCRIPTION
Log warning if log key does not exist in the log

I decided to add warning message as raising exception may lead to re-ingest logs in current architecture