### PR TITLE
chore(vagrant): upgrade Ruby to 3.3

### DIFF
--- a/fluent-plugin-sumologic_output.gemspec
+++ b/fluent-plugin-sumologic_output.gemspec
@@ -17,12 +17,10 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = '>= 2.0.0'
-
-  gem.add_development_dependency "bundler", "~> 2"
+  gem.add_development_dependency "bundler"
   gem.add_development_dependency "rake"
-  gem.add_development_dependency 'test-unit', '~> 3.1.0'
-  gem.add_development_dependency "codecov", ">= 0.1.10"
-  gem.add_runtime_dependency "fluentd", ">= 0.14.12"
-  gem.add_runtime_dependency 'httpclient', '~> 2.8.0'
+  gem.add_development_dependency 'test-unit'
+  gem.add_development_dependency "codecov"
+  gem.add_runtime_dependency "fluentd"
+  gem.add_runtime_dependency 'httpclient'
 end

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -22,6 +22,5 @@ usermod -aG docker vagrant
 apt-get install -y make
 
 # install requirements for ruby
-snap install ruby --channel=2.6/stable --classic
-su vagrant -c 'gem install bundler:2.1.4'
+snap install ruby --channel=3.3/stable --classic
 apt install -y gcc g++ libsnappy-dev libicu-dev zlib1g-dev cmake pkg-config libssl-dev


### PR DESCRIPTION
Removed bundler installation because bundler is shipped with the snap.

Removed the existing outdated gem version limitations from gemspec. This was necessary for the tests to pass.