### PR TITLE
chore: add arm support to vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-unless Vagrant.has_plugin?("vagrant-disksize")
-  puts "vagrant-disksize plugin unavailable\n" +
-       "please install it via 'vagrant plugin install vagrant-disksize'"
-  exit 1
-end
-
 Vagrant.configure('2') do |config|
   config.vm.box = 'ubuntu/focal64'
-  config.disksize.size = '50GB'
+  config.vm.disk :disk, size: "50GB", primary: true
   config.vm.box_check_update = false
   config.vm.host_name = 'fluentd-output-sumologic'
   # Vbox 6.1.28+ restricts host-only adapters to 192.168.56.0/21
@@ -21,6 +15,14 @@ Vagrant.configure('2') do |config|
     vb.cpus = 8
     vb.memory = 16384
     vb.name = 'fluentd-output-sumologic'
+  end
+
+  config.vm.provider "qemu" do |qe, override|
+    override.vm.box = "perk/ubuntu-2204-arm64"
+    qe.gui = false
+    qe.smp = 8
+    qe.memory = 16384
+    qe.name = 'fluentd-output-sumologic'
   end
 
   config.vm.provision 'shell', path: 'vagrant/provision.sh'

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -5,16 +5,28 @@
 Please install the following:
 
 - [VirtualBox](https://www.virtualbox.org/)
-- [Vagrant](https://www.vagrantup.com/)
-- [vagrant-disksize](https://github.com/sprotheroe/vagrant-disksize) plugin
+- [Vagrant](https://developer.hashicorp.com/vagrant/downloads)
+
+### General
+
+1. Install `vagrant` as per <https://developer.hashicorp.com/vagrant/downloads>
+2. Configure a provider
+3. Run `vagrant up` and then `vagrant ssh`
 
 ### MacOS
 
 ```bash
 brew cask install virtualbox
 brew cask install vagrant
-vagrant plugin install vagrant-disksize
 ```
+
+### ARM hosts (Apple M1, and so on)
+
+You'll need to use QEMU instead of VirtualBox to use Vagrant on ARM. The following instructions will assume an M1 Mac as the host:
+
+1. Install QEMU: `brew install qemu`
+2. Install the QEMU vagrant provider: `vagrant plugin install vagrant-qemu`
+3. Provision the VM with the provider: `vagrant up --provider=qemu`
 
 ## Setting up
 

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -3,6 +3,8 @@
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
+ARCH="$(dpkg --print-architecture)"
+
 apt-get update
 apt-get --yes upgrade
 apt-get --yes install apt-transport-https
@@ -12,7 +14,7 @@ echo "export EDITOR=vim" >> /home/vagrant/.bashrc
 # Install docker
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   "deb [arch=${ARCH}] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
    stable"
 apt-get install -y docker-ce docker-ce-cli containerd.io
@@ -22,5 +24,14 @@ usermod -aG docker vagrant
 apt-get install -y make
 
 # install requirements for ruby
-snap install ruby --channel=3.3/stable --classic
-apt install -y gcc g++ libsnappy-dev libicu-dev zlib1g-dev cmake pkg-config libssl-dev
+apt install -y \
+   gcc \
+   g++ \
+   libsnappy-dev \
+   libicu-dev \
+   zlib1g-dev \
+   cmake \
+   pkg-config \
+   libssl-dev \
+   ruby-dev \
+   ruby-bundler


### PR DESCRIPTION
Add arm support
Install `ruby` from `apt` to provide matching `ruby-dev`