### PR TITLE
make receive_timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Configuration options for fluent.conf are:
   * json_merge - Same as json but merge content of `log_key` into the top level and strip `log_key`
 * `log_key` - Used to specify the key when merging json or sending logs in text format (default `message`)
 * `open_timeout` - Set timeout seconds to wait until connection is opened.
+* `receieve_timeout` - Set timeout seconds to wait for a response from SumoLogic in seconds. Don't modify unless you see `HTTPClient::ReceiveTimeoutError` in your Fluentd logs. 
 * `send_timeout` - Timeout for sending to SumoLogic in seconds. Don't modify unless you see `HTTPClient::SendTimeoutError` in your Fluentd logs. (default `120`)
 * `add_timestamp` - Add `timestamp` (or `timestamp_key`) field to logs before sending to sumologic (default `true`)
 * `timestamp_key` - Field name when `add_timestamp` is on (default `timestamp`)


### PR DESCRIPTION
This exposes the `httpclient` receive_timeout property to be configurable by the end-user. This can be a useful setting to adjust when users hit errors like:
```
[warn]: #0 failed to flush the buffer. retry_times=0 next_retry_time=2024-09-26 18:35:54 +0000 chunk="REDACTED" error_class=HTTPClient::ReceiveTimeoutError error="execution expired"
2024-09-26T18:35:52.924897251Z 2024-09-26 18:35:52.924711734 +0000 fluent.warn: {"retry_times":0,"next_retry_time":"2024-09-26 18:35:54 +0000","chunk":"REDACTED","error":"#<HTTPClient::ReceiveTimeoutError: execution expired>","message":"failed to flush the buffer. retry_times=0 next_retry_time=2024-09-26 18:35:54 +0000 chunk=\"REDACTED\" error_class=HTTPClient::ReceiveTimeoutError error=\"execution expired\""}
```